### PR TITLE
Fix media display issue in MediaManager

### DIFF
--- a/client/src/pages/media-manager.tsx
+++ b/client/src/pages/media-manager.tsx
@@ -228,23 +228,26 @@ export default function MediaManager() {
                 {mediaItems.map((item) => (
                   <div key={item.id} className="border rounded-lg overflow-hidden bg-white shadow-sm">
                     <div className="relative">
-                      {item.media_type === 'image' ? (
-                        <img 
-                          src={item.file_url || ""} 
-                          alt={item.name}
-                          className="w-full h-48 object-cover"
-                          onError={(e) => {
-                            e.currentTarget.src = '/placeholder-image.jpg';
-                          }}
-                        />
-                      ) : (
-                        <video 
-                          src={item.file_url || ""}
-                          className="w-full h-48 object-cover"
-                          controls
-                          preload="metadata"
-                        />
-                      )}
+                      {(() => {
+                        const mediaSrc = item.file_url || `/api/media/${item.id}/file`;
+                        return item.media_type === 'image' ? (
+                          <img 
+                            src={mediaSrc}
+                            alt={item.name}
+                            className="w-full h-48 object-cover"
+                            onError={(e) => {
+                              e.currentTarget.src = '/placeholder-image.jpg';
+                            }}
+                          />
+                        ) : (
+                          <video 
+                            src={mediaSrc}
+                            className="w-full h-48 object-cover"
+                            controls
+                            preload="metadata"
+                          />
+                        );
+                      })()}
                       <div className="absolute top-2 right-2">
                         <Button
                           size="sm"

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -98,13 +98,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (!item || (!item.image_data && !item.image_url)) {
         return res.status(404).json({ message: "Image not found" });
       }
-      
-      res.set({
-        'Content-Type': item.file_size ? 'image/jpeg' : 'application/octet-stream'
-      });
-      
+
+      // Choose appropriate content type based on stored mime or file extension
+      const inferredType =
+        item.name?.toLowerCase().endsWith(".png") ? "image/png" :
+        item.name?.toLowerCase().endsWith(".gif") ? "image/gif" :
+        "image/jpeg";
+
+      // If your storage stores mime type for promo, prefer it. Cast to any to avoid schema constraints.
+      const contentType = (item as any).mime_type || inferredType;
+
+      res.set({ "Content-Type": contentType });
+
       if (item.image_data) {
-        const buffer = Buffer.from(item.image_data, 'base64');
+        const buffer = Buffer.from(item.image_data, "base64");
         res.send(buffer);
       } else if (item.image_url) {
         res.redirect(item.image_url);


### PR DESCRIPTION
This pull request addresses the issue where media files were not being displayed correctly in the MediaManager component. Instead of the actual media item, only the file name was shown. The changes update the way media sources are retrieved based on the media type. The media source now falls back to a specific API endpoint (`/api/media/${item.id}/file`) if the `file_url` is not provided. This ensures that images and videos are displayed properly, enhancing user experience.

---

> This pull request was co-created with Cosine Genie

Original Task: [replit_dj_tv_display/eviz0tt6jv20](https://cosine.sh/znudrvw3hn93/replit_dj_tv_display/task/eviz0tt6jv20)
Author: ipadyptab
