### PR TITLE
Remove Company Logo from TV Display Header

### DIFF
--- a/client/src/pages/tv-display.tsx
+++ b/client/src/pages/tv-display.tsx
@@ -189,22 +189,9 @@ export default function TVDisplay() {
             transition={{ duration_seconds: 0.5, ease: "easeInOut" }}
             className="flex-1 flex flex-col"
           >
-            {/* Header with Company Logo - Responsive for all devices */}
+            {/* Header without Company Logo */}
             <div className={`relative bg-gradient-to-r from-jewelry-primary to-jewelry-secondary text-white flex-shrink-0 ${screenSize === 'tv' ? 'py-6' : screenSize === 'tablet' ? 'py-3' : 'py-2 md:py-4'}`}>
-              <div className="container mx-auto px-2 md:px-4 flex items-center justify-between">
-                <div className="flex items-center space-x-2 md:space-x-4">
-                  <div className="w-10 h-10 md:w-16 md:h-16 bg-gold-500 rounded-full flex items-center justify-center shadow-lg">
-                    <img 
-                      src="/logo.png" 
-                      alt="Devi Jewellers Logo"
-                      className="w-8 h-8 md:w-12 md:h-12 object-contain"
-                    />
-                  </div>
-                  <div className={screenSize === 'mobile' ? "hidden md:block" : ""}>
-                    <p className="text-gold-200 text-xs md:text-sm">Premium Gold & Silver Collection</p>
-                  </div>
-                </div>
-                
+              <div className="container mx-auto px-2 md:px-4 flex items-center justify-end">
                 {/* Date and Time */}
                 <div className="text-right bg-black bg-opacity-30 px-3 py-1 md:px-6 md:py-3 rounded-lg backdrop-blur-sm">
                   <div className="text-sm md:text-lg font-semibold text-gold-200">


### PR DESCRIPTION
This PR modifies the TV display page to remove the company logo from the header while maintaining the existing structure for responsive design. The logo was previously included as part of the header, and its removal allows for a cleaner presentation on the TV display. The changes are made in the `tv-display.tsx` file.

---

> This pull request was co-created with Cosine Genie

Original Task: [replit_dj_tv_display/2t73hh0luj31](https://cosine.sh/znudrvw3hn93/replit_dj_tv_display/task/2t73hh0luj31)
Author: ipadyptab
