### PR TITLE
Add logo to TV display page header

### DIFF
--- a/client/src/pages/tv-display.tsx
+++ b/client/src/pages/tv-display.tsx
@@ -193,13 +193,12 @@ export default function TVDisplay() {
             <div className={`relative bg-gradient-to-r from-jewelry-primary to-jewelry-secondary text-white flex-shrink-0 ${screenSize === 'tv' ? 'py-6' : screenSize === 'tablet' ? 'py-3' : 'py-2 md:py-4'}`}>
               <div className="container mx-auto px-2 md:px-4 flex items-center justify-between">
                 <div className="flex items-center space-x-2 md:space-x-4">
-                  <div className="w-10 h-10 md:w-16 md:h-16 bg-gold-500 rounded-full flex items-center justify-center shadow-lg">
-                    <img 
-                      src="/logo.png" 
-                      alt="Devi Jewellers Logo"
-                      className="w-8 h-8 md:w-12 md:h-12 object-contain"
-                    />
-                  </div>
+                  {/* Page header logo */}
+                  <img
+                    src="/logo.jpeg"
+                    alt="Company Logo"
+                    className={`${screenSize === 'tv' ? 'h-20' : 'h-10 md:h-16'} w-auto object-contain drop-shadow`}
+                  />
                   <div className={screenSize === 'mobile' ? "hidden md:block" : ""}>
                     <p className="text-gold-200 text-xs md:text-sm">Premium Gold & Silver Collection</p>
                   </div>


### PR DESCRIPTION
This pull request updates the TV display page to replace the existing icon with a company logo. The logo is now included as a page header, improving brand visibility. The image source has been changed from 'logo.png' to 'logo.jpeg', and it is styled to vary its height based on the screen size. This enhancement helps in providing a cohesive branding experience on the TV display page.

---

> This pull request was co-created with Cosine Genie

Original Task: [replit_dj_tv_display/ovzo8ls96kq9](https://cosine.sh/znudrvw3hn93/replit_dj_tv_display/task/ovzo8ls96kq9)
Author: ipadyptab
